### PR TITLE
☯️ Render DecaDojo events by YAML data for easier maintenance

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,0 +1,7 @@
+---
+- id:  senboku
+  url: https://peraichi.com/landing_pages/view/decadojosenboku
+  img: senboku.jpg
+  title: in Senboku / 泉北
+  description: |
+    CoderDojo堺は2016年2月から活動を始めた、大阪府で2番目の道場。2017年は「泉北ニュータウンまちびらき50周年事業」とコラボレーションし、毎月1回 CoderDojo堺を開催。その集大成として12月に「でかドージョー」を実施することになりました。

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,7 +1,20 @@
 ---
-- id:  senboku
-  url: https://peraichi.com/landing_pages/view/decadojosenboku
+- url: https://peraichi.com/landing_pages/view/decadojosenboku
   img: senboku.jpg
-  title: in Senboku / 泉北
+  title: Senboku / 泉北
   description: |
     CoderDojo堺は2016年2月から活動を始めた、大阪府で2番目の道場。2017年は「泉北ニュータウンまちびらき50周年事業」とコラボレーションし、毎月1回 CoderDojo堺を開催。その集大成として12月に「でかドージョー」を実施することになりました。
+
+- url: https://peraichi.com/landing_pages/view/decadojoyokoze
+  img: yokoze.jpg
+  title: Yokoze / 横瀬
+  description: |
+    2017年11月、CoderDojo横瀬がオープン。そのオープン記念として「でかドージョー」の第2回目を開催。会場は廃校になった小学校で運営されているコワーキングスペース！学びの場としてこれ以上ない場所で開催されました。
+
+- url: https://peraichi.com/landing_pages/view/decadojo
+  img: tokorozawa.jpg
+  title: Tokorozawa / 所沢
+  description: |
+    所沢の「つくる、を楽しむ」をテーマとした「.Makeところざわ」というイベントの一環として実施。近隣のDojoと共同でおっきなDojoを開催したら、なんか楽しいんじゃないか、という漠然とした思いつきを、近隣のチャンピオンが受け入れてくれ、第１回目の開催となりました。
+
+

--- a/index.html
+++ b/index.html
@@ -1,3 +1,6 @@
+---
+---
+
 <!DOCTYPE html>
 <html class="pc" lang="ja">
   <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb#">
@@ -187,10 +190,10 @@
           </div>
 
 	  <div class="index_box_list clearfix">
-	    <div class="box box1 clearfix">
+	    <div class="box clearfix">
               <div class="image">
 		<a href="https://peraichi.com/landing_pages/view/decadojosenboku">
-		  <img src="/img/senboku.jpg" title="DecaDojo Senboku" alt="DecaDojo Senboku" />
+		  <img src="/img/senboku.jpg" title="DecaDojo @ Senboku" alt="DecaDojo @ Senboku" />
 		</a>
 	      </div>
 
@@ -208,7 +211,7 @@
 	      </div>
 	    </div>
 
-	    <div class="box box2 clearfix">
+	    <div class="box clearfix">
               <div class="image">
 		<a href="https://peraichi.com/landing_pages/view/decadojoyokoze">
 		  <img src="/img/yokoze.jpg" title="DecaDojo Yokoze" alt="DecaDojo Yokoze" />
@@ -229,7 +232,7 @@
 	      </div>
 	    </div>
 
-	    <div class="box box3 clearfix">
+	    <div class="box clearfix">
               <div class="image">
 		<a href="https://peraichi.com/landing_pages/view/decadojo">
 		  <img src="/img/tokorozawa.jpg" title="DecaDojo Tokorozawa" alt="DecaDojo Tokorozawa" />

--- a/index.html
+++ b/index.html
@@ -190,67 +190,25 @@
           </div>
 
 	  <div class="index_box_list clearfix">
+
+	    {% for event in site.data.events %}
 	    <div class="box clearfix">
               <div class="image">
-		<a href="https://peraichi.com/landing_pages/view/decadojosenboku">
-		  <img src="/img/senboku.jpg" title="DecaDojo @ Senboku" alt="DecaDojo @ Senboku" />
+		<a href="{{ event.url }}">
+		  <img src="/img/{{ event.img }}" title="DecaDojo @ {{ event.title }}" alt="DecaDojo @ {{ event.title }}" />
 		</a>
 	      </div>
 
               <div class="info">
-		<h4 class="headline rich_font">in Senboku / 泉北</h4>
+		<h4 class="headline rich_font">in {{ event.title }}</h4>
 		<div class="desc">
-		  <p>
-		    <!--
-			 場所：大阪府大阪狭山市
-			 日程：2017年12月３日（日）
-		    -->
-		    CoderDojo堺は2016年2月から活動を始めた、大阪府で2番目の道場。2017年は「泉北ニュータウンまちびらき50周年事業」とコラボレーションし、毎月1回 CoderDojo堺を開催。その集大成として12月に「でかドージョー」を実施することになりました。</p>
+		  <p>{{ event.description }}</p>
 		</div>
-		<a href="https://peraichi.com/landing_pages/view/decadojosenboku" class="link">詳細を見る</a>
+		<a href="{{ event.url }}" class="link">詳細を見る</a>
 	      </div>
 	    </div>
+	    {% endfor %}
 
-	    <div class="box clearfix">
-              <div class="image">
-		<a href="https://peraichi.com/landing_pages/view/decadojoyokoze">
-		  <img src="/img/yokoze.jpg" title="DecaDojo Yokoze" alt="DecaDojo Yokoze" />
-		</a>
-	      </div>
-
-              <div class="info">
-		<h4 class="headline rich_font">in Yokoze / 横瀬</h4>
-		<div class="desc">
-		  <p>
-		    <!--
-		    場所：埼玉県秩父郡横瀬町
-		    日程：2017年11月4日（土）
-		    -->
-		    2017年11月、CoderDojo横瀬がオープン。そのオープン記念として「でかドージョー」の第2回目を開催。会場は廃校になった小学校で運営されているコワーキングスペース！学びの場としてこれ以上ない場所で開催されました。</p>
-		</div>
-		<a href="https://peraichi.com/landing_pages/view/decadojoyokoze" class="link">詳細を見る</a>
-	      </div>
-	    </div>
-
-	    <div class="box clearfix">
-              <div class="image">
-		<a href="https://peraichi.com/landing_pages/view/decadojo">
-		  <img src="/img/tokorozawa.jpg" title="DecaDojo Tokorozawa" alt="DecaDojo Tokorozawa" />
-		</a>
-	      </div>
-
-              <div class="info">
-		<h4 class="headline rich_font">in Tokorozawa / 所沢</h4>
-		<div class="desc">
-		  <p>
-		    <!--
-		    場所：埼玉県所沢市
-		    日程：2017年5月7日（日）
-		    -->
-		    所沢の「つくる、を楽しむ」をテーマとした「.Makeところざわ」というイベントの一環として実施。近隣のDojoと共同でおっきなDojoを開催したら、なんか楽しいんじゃないか、という漠然とした思いつきを、近隣のチャンピオンが受け入れてくれ、第１回目の開催となりました。</p>
-		</div>
-		<a href="https://peraichi.com/landing_pages/view/decadojo" class="link">詳細を見る</a>    </div>
-	    </div>
 	  </div><!-- END .index_box -->
 	</div><!-- END .index_content1 -->
       </div><!-- END #index_content2 -->

--- a/responsive.css
+++ b/responsive.css
@@ -139,7 +139,6 @@ body { min-width:0; }
   .index_box_list .image { width:100%; float:none; margin:0 0 30px 0; }
   .index_box_list .info { width:100%; float:none; padding:0; position:relative;  }
   .index_box_list .link { margin:0 auto 30px; }
-  .index_box_list .box3 .link { margin-bottom:0; }
   .index_box_list .desc { font-size:14px; }
 }
 

--- a/style.css
+++ b/style.css
@@ -347,8 +347,7 @@ a:hover { text-decoration:underline; }
 
 /* コンテンツ１ */
 .index_box_list { padding:60px 0 65px 0; display:flex; display: -webkit-flex; display:-ms-flexbox;/*--- IE10 ---*/ }
-.index_box_list .box { width:360px; margin:0 60px 0 0; padding:0 0 75px 0; position:relative; }
-.index_box_list .box.box3 { margin:0; }
+.index_box_list .box { width:360px; margin:0 30px 0 30px; padding:0 0 75px 0; position:relative; }
 .index_box_list .image { width:100%; height:auto; display:block; margin:0 0 25px 0; overflow:hidden; }
 .index_box_list .image img {
   width:100%; height:auto; display:block;


### PR DESCRIPTION
NOTE: まずは既存のページの抽象化から。新しい DecaDojo 情報を追加は後で。

- [x] Render existing LP as Liquid template && Tweak CSS for templating d0698e6
- [x] テンプレートとして切り出し、データ部分は YAML に移行
- [x] YAML からページを描画し、以前と同じ状態で表示できることを確認
   <img width="1265" alt="image" src="https://github.com/coderdojo-japan/decadojo/assets/155807/47c93e34-4b9e-4160-ac1a-f03988b3ff71">
